### PR TITLE
Make two outputs: hyperspy-base and hyperspy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About hyperspy
-==============
+About hyperspy-meta
+===================
 
 Home: https://hyperspy.org
 
@@ -16,7 +16,7 @@ Current build status
 
 [![Linux](https://img.shields.io/circleci/project/github/conda-forge/hyperspy-feedstock/master.svg?label=Linux)](https://circleci.com/gh/conda-forge/hyperspy-feedstock)
 [![OSX](https://img.shields.io/travis/conda-forge/hyperspy-feedstock/master.svg?label=macOS)](https://travis-ci.org/conda-forge/hyperspy-feedstock)
-[![Windows](https://img.shields.io/appveyor/ci/conda-forge/hyperspy-feedstock/master.svg?label=Windows)](https://ci.appveyor.com/project/conda-forge/hyperspy-feedstock/branch/master)
+![Windows disabled](https://img.shields.io/badge/Windows-disabled-lightgrey.svg)
 
 Current release info
 ====================
@@ -24,20 +24,22 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-hyperspy-green.svg)](https://anaconda.org/conda-forge/hyperspy) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/hyperspy.svg)](https://anaconda.org/conda-forge/hyperspy) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/hyperspy.svg)](https://anaconda.org/conda-forge/hyperspy) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/hyperspy.svg)](https://anaconda.org/conda-forge/hyperspy) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-hyperspy--base-green.svg)](https://anaconda.org/conda-forge/hyperspy-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/hyperspy-base.svg)](https://anaconda.org/conda-forge/hyperspy-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/hyperspy-base.svg)](https://anaconda.org/conda-forge/hyperspy-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/hyperspy-base.svg)](https://anaconda.org/conda-forge/hyperspy-base) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-hyperspy--dev-green.svg)](https://anaconda.org/conda-forge/hyperspy-dev) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/hyperspy-dev.svg)](https://anaconda.org/conda-forge/hyperspy-dev) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/hyperspy-dev.svg)](https://anaconda.org/conda-forge/hyperspy-dev) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/hyperspy-dev.svg)](https://anaconda.org/conda-forge/hyperspy-dev) |
 
-Installing hyperspy
-===================
+Installing hyperspy-meta
+========================
 
-Installing `hyperspy` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `hyperspy-meta` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `hyperspy` can be installed with:
+Once the `conda-forge` channel has been enabled, `hyperspy, hyperspy-base, hyperspy-dev` can be installed with:
 
 ```
-conda install hyperspy
+conda install hyperspy hyperspy-base hyperspy-dev
 ```
 
 It is possible to list all of the versions of `hyperspy` available on your platform with:
@@ -83,17 +85,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating hyperspy-feedstock
-===========================
+Updating hyperspy-meta-feedstock
+================================
 
-If you would like to improve the hyperspy recipe or build a new
+If you would like to improve the hyperspy-meta recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/hyperspy-feedstock are
+Note that all branches in the conda-forge/hyperspy-meta-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -1,0 +1,3 @@
+%PYTHON% -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+if errorlevel 1 exit 1
+

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "1.4.1" %}
 
 package:
-  name: hyperspy
+  name: hyperspy-split
   version: {{ version }}
 
 source:
@@ -15,7 +15,8 @@ build:
 
 outputs:
   - name: hyperspy-base
-    script: "python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+    script: install.sh  # [not win]
+    script: install.bat  # [win]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -52,20 +53,20 @@ outputs:
       requires:
         - pytest
         - matplotlib <3.0  
-        - pillow >5.2
+        - pytest-mpl
       commands:
         - export MPLBACKEND=agg  # [unix]
         - set MPLBACKEND=agg  # [win]
         - py.test --pyargs hyperspy --mpl
+
   - name: hyperspy
     requirements:
-      host:
-        - python
       run:
         - python
+        - pyqt
         - {{ pin_subpackage('hyperspy-base', exact=True) }}
-        - hyperspy-gui-ipywidgets
-        - hyperspy-gui-traitsui
+        - hyperspy-gui-ipywidgets >=1.1
+        - hyperspy-gui-traitsui >=1.1
 
 about:
   home: https://hyperspy.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,24 +55,6 @@ outputs:
         - pytest
         - matplotlib <3.0  
         - pytest-mpl
-      commands:
-        - export MPLBACKEND=agg  # [unix]
-        - set MPLBACKEND=agg  # [win]
-        - py.test --pyargs hyperspy --mpl
-
-  - name: hyperspy
-    requirements:
-      run:
-        - python
-        - pyqt
-        - {{ pin_subpackage('hyperspy-base', exact=True) }}
-        - hyperspy-gui-ipywidgets >=1.1
-        - hyperspy-gui-traitsui >=1.1
-        - jupyterlab >=0.35.4
-        - nodejs
-    test:
-      commands:
-        - export QT_QPA_PLATFORM=offscreen  # [unix]
       imports:
         - hyperspy
         - hyperspy.Release
@@ -121,6 +103,21 @@ outputs:
         - hyperspy.samfire_utils.segmenters
         - hyperspy.samfire_utils.weights
         - hyperspy.utils
+      commands:
+        - export MPLBACKEND=agg  # [unix]
+        - set MPLBACKEND=agg  # [win]
+        - pytest --pyargs hyperspy --mpl
+
+  - name: hyperspy
+    requirements:
+      run:
+        - python
+        - pyqt
+        - {{ pin_subpackage('hyperspy-base', exact=True) }}
+        - hyperspy-gui-ipywidgets >=1.1
+        - hyperspy-gui-traitsui >=1.1
+        - jupyterlab >=0.35.4
+        - nodejs
 
   - name: hyperspy-dev
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ outputs:
         - numba
         - numexpr
         - sparse
+        - pillow >5.2  # [win]
     test:
       requires:
         - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
 
 outputs:
   - name: hyperspy-base
-    script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+    script: "python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,6 +136,8 @@ about:
   license: GPL v3
   summary: Multi-dimensional data analysis
   license_file: COPYING.txt
+  dev_url: https://github.com/hyperspy/hyperspy/
+  doc_url: http://hyperspy.org/hyperspy-doc/current/user_guide/index.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,9 +59,11 @@ outputs:
         - py.test --pyargs hyperspy --mpl
   - name: hyperspy
     requirements:
+      host:
+        - python
       run:
         - python
-        - hyperspy-base {{ version }}
+        - {{ pin_subpackage('hyperspy-base', exact=True) }}
         - hyperspy-gui-ipywidgets >=1.1
         - hyperspy-gui-traitsui >=1.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,6 +68,55 @@ outputs:
         - {{ pin_subpackage('hyperspy-base', exact=True) }}
         - hyperspy-gui-ipywidgets >=1.1
         - hyperspy-gui-traitsui >=1.1
+    test:
+      imports:
+        - hyperspy
+        - hyperspy.Release
+        # - hyperspy._lazy_signals
+        - hyperspy.api
+        - hyperspy.api_nogui
+        - hyperspy.axes
+        - hyperspy.component
+        - hyperspy.components1d
+        - hyperspy.components2d
+        - hyperspy.decorators
+        - hyperspy.defaults_parser
+        - hyperspy.events
+        - hyperspy.exceptions
+        - hyperspy.interactive
+        - hyperspy.io
+        - hyperspy.logger
+        - hyperspy.model
+        - hyperspy.roi
+        - hyperspy.samfire
+        - hyperspy.signal
+        - hyperspy.signal_tools
+        - hyperspy.signals
+        - hyperspy.ui_registry
+        - hyperspy._components
+        - hyperspy._signals
+        - hyperspy.datasets
+        - hyperspy.docstrings
+        - hyperspy.drawing
+        - hyperspy.drawing._markers
+        - hyperspy.drawing._widgets
+        - hyperspy.external
+        - hyperspy.external.astroML
+        - hyperspy.external.mpfit
+        - hyperspy.io_plugins
+        - hyperspy.learn
+        - hyperspy.misc
+        - hyperspy.misc.eds
+        - hyperspy.misc.eels
+        - hyperspy.misc.holography
+        - hyperspy.misc.io
+        - hyperspy.misc.machine_learning
+        - hyperspy.models
+        - hyperspy.samfire_utils
+        - hyperspy.samfire_utils.goodness_of_fit_tests
+        - hyperspy.samfire_utils.segmenters
+        - hyperspy.samfire_utils.weights
+        - hyperspy.utils
 
 about:
   home: https://hyperspy.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,56 +10,61 @@ source:
   sha256: 1527bc374e539b07d64e6d95ac30b351c3e9ed0183886084b993f70c696045d9 
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py2k]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
-requirements:
-  build:
-    - {{ compiler('c') }}
-  host:
-    - python
-    - setuptools
-    - cython
-    - pip
-  run:
-    - python
-    - dill
-    - h5py
-    - ipython
-    - jupyter
-    - matplotlib >2.2.2
-    - numpy >1.13
-    - scikit-image >=0.13
-    - scikit-learn
-    - scipy >=0.15
-    - statsmodels
-    - ipyparallel
-    - sympy
-    - natsort
-    - dask >=0.18
-    - traits >=4.5
-    - requests
-    - tqdm >=0.4.9
-    - python-dateutil >=2.5
-    - backports_abc  # [py34]
-    - pint >0.8
-    - numba
-    - numexpr
-    # - hyperspy-gui-ipywidgets >=1.1
-    # - hyperspy-gui-traitsui >=1.1
-    - sparse
-test:
-    requires:
+outputs:
+  - name: hyperspy-base
+    requirements:
+      build:
+        - {{ compiler('c') }}
+      host:
+        - python
+        - setuptools
+        - cython
+        - pip
+      run:
+        - python
+        - dill
+        - h5py
+        - ipython
+        - jupyter
+        - matplotlib >2.2.2
+        - numpy >1.13
+        - scikit-image >=0.13
+        - scikit-learn
+        - scipy >=0.15
+        - statsmodels
+        - ipyparallel
+        - sympy
+        - natsort
+        - dask >=0.18
+        - traits >=4.5
+        - requests
+        - tqdm >=0.4.9
+        - python-dateutil >=2.5
+        - pint >0.8
+        - numba
+        - numexpr
+        - sparse
+    test:
+      requires:
         - pytest
-        - pytest-mpl
-        - freetype 2.9.*
         - matplotlib <3.0  
         - pillow >5.2
-    commands:
+      commands:
         - export MPLBACKEND=agg  # [unix]
         - set MPLBACKEND=agg  # [win]
         - py.test --pyargs hyperspy --mpl
+  - name: hyperspy
+      host:
+        - python
+      run:
+        - python
+        - hyperspy-base {{ version }}
+        - hyperspy-gui-ipywidgets >=1.1
+        - hyperspy-gui-traitsui >=1.1
 
 about:
   home: https://hyperspy.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,6 +118,19 @@ outputs:
         - hyperspy.samfire_utils.weights
         - hyperspy.utils
 
+  - name: hyperspy-dev
+    requirements:
+      run:
+        - python
+        - cython
+        - {{ pin_subpackage('hyperspy-base', exact=True) }}
+        - pytest
+        - pytest-mpl
+        - matplotlib <3.0  
+        - numpydoc
+        - sphinx
+        - sphinx_rtd_theme
+
 about:
   home: https://hyperspy.org
   license: GPL v3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "1.4.1" %}
 
 package:
-  name: hyperspy-split
+  name: hyperspy-meta
   version: {{ version }}
 
 source:
@@ -68,7 +68,11 @@ outputs:
         - {{ pin_subpackage('hyperspy-base', exact=True) }}
         - hyperspy-gui-ipywidgets >=1.1
         - hyperspy-gui-traitsui >=1.1
+        - jupyterlab >=0.35.4
+        - nodejs
     test:
+      commands:
+        - export QT_QPA_PLATFORM=offscreen  # [unix]
       imports:
         - hyperspy
         - hyperspy.Release

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ source:
 build:
   number: 1
   skip: True  # [py2k]
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 outputs:
   - name: hyperspy-base
+    script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
     requirements:
       build:
         - {{ compiler('c') }}
@@ -59,8 +59,6 @@ outputs:
         - py.test --pyargs hyperspy --mpl
   - name: hyperspy
     requirements:
-      host:
-        - python
       run:
         - python
         - hyperspy-base {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,8 +64,8 @@ outputs:
       run:
         - python
         - {{ pin_subpackage('hyperspy-base', exact=True) }}
-        - hyperspy-gui-ipywidgets >=1.1
-        - hyperspy-gui-traitsui >=1.1
+        - hyperspy-gui-ipywidgets
+        - hyperspy-gui-traitsui
 
 about:
   home: https://hyperspy.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,7 @@ outputs:
         - set MPLBACKEND=agg  # [win]
         - py.test --pyargs hyperspy --mpl
   - name: hyperspy
+    requirements:
       host:
         - python
       run:


### PR DESCRIPTION
Attempt to make several outputs to install guis and development tools:
- `hyperspy-base` is the `hyperspy` pypi package
- `hyperspy` is a meta-package: it installs `hyperspy-base` + guis
- `hyperspy-dev` is a meta-package: it installs `hyperspy` + the development tools (cython, pytest, libraries to build the doc, etc.)

It re-introduces the installation of GUIs (similarly to #26) and it should allow:
```
conda install hyperspy-base --only-deps -c conda-forge
```
as mentioned in https://github.com/hyperspy/hyperspy/issues/1950#issuecomment-390385929.
