### PR TITLE
Fix the filename of the different output packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Current build status
 
 [![Linux](https://img.shields.io/circleci/project/github/conda-forge/hyperspy-feedstock/master.svg?label=Linux)](https://circleci.com/gh/conda-forge/hyperspy-feedstock)
 [![OSX](https://img.shields.io/travis/conda-forge/hyperspy-feedstock/master.svg?label=macOS)](https://travis-ci.org/conda-forge/hyperspy-feedstock)
-![Windows disabled](https://img.shields.io/badge/Windows-disabled-lightgrey.svg)
+[![Windows](https://img.shields.io/appveyor/ci/conda-forge/hyperspy-feedstock/master.svg?label=Windows)](https://ci.appveyor.com/project/conda-forge/hyperspy-feedstock/branch/master)
 
 Current release info
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,10 @@ build:
   number: 1002
   skip: True  # [py2k]
 
+requirements:
+  host:
+    - python
+
 outputs:
   - name: hyperspy-base
     script: install.sh  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,6 +114,8 @@ outputs:
 
   - name: hyperspy
     requirements:
+      host:
+        - python
       run:
         - python
         - pyqt
@@ -125,6 +127,8 @@ outputs:
 
   - name: hyperspy-dev
     requirements:
+      host:
+        - python
       run:
         - python
         - cython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1527bc374e539b07d64e6d95ac30b351c3e9ed0183886084b993f70c696045d9 
 
 build:
-  number: 1
+  number: 1002
   skip: True  # [py2k]
 
 outputs:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The osx package for the hyperspy metapackage is only available with the `gcc7` label -see https://anaconda.org/conda-forge/hyperspy/files. It looks to me that when travis try to upload the package, there is [already one package with the same name](https://travis-ci.org/conda-forge/hyperspy-feedstock/jobs/461233355#L3669) which prevent uploading the package to the `main` label.