### PR TITLE
Add osx-arm

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,12 @@ jobs:
       osx_64_python3.9.____cpython:
         CONFIG: osx_64_python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.8.____cpython:
+        CONFIG: osx_arm64_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.9.____cpython:
+        CONFIG: osx_arm64_python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -1,0 +1,20 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge/label/rust_dev,conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -1,0 +1,20 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge/label/rust_dev,conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-arm64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -45,6 +45,10 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
+
 
 ( endgroup "Configuring conda" ) 2> /dev/null
 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -52,11 +52,11 @@ if [ -z "${DOCKER_IMAGE}" ]; then
         echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
         DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
         if [ "${DOCKER_IMAGE}" = "" ]; then
-            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
-            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+            echo "No docker_image entry found in ${CONFIG}. Falling back to quay.io/condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="quay.io/condaforge/linux-anvil-comp7"
         fi
     else
-        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 quay.io/condaforge/linux-anvil-comp7 )"
     fi
 fi
 

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -4,12 +4,14 @@ source .scripts/logging_utils.sh
 
 set -xe
 
+MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
+
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
 MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
-bash $MINIFORGE_FILE -b
+bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
@@ -17,7 +19,7 @@ bash $MINIFORGE_FILE -b
 
 BUILD_CMD=build
 
-source ${HOME}/miniforge3/etc/profile.d/conda.sh
+source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
@@ -27,11 +29,18 @@ conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${G
 
 echo -e "\n\nSetting up the condarc and mangling the compiler."
 setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
-mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
 
-echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
-/usr/bin/sudo mangle_homebrew
-/usr/bin/sudo -k
+if [[ "${CI:-}" != "" ]]; then
+  mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+fi
+
+if [[ "${CI:-}" != "" ]]; then
+  echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+  /usr/bin/sudo mangle_homebrew
+  /usr/bin/sudo -k
+else
+  echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
 
 echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
@@ -43,6 +52,10 @@ source run_conda_forge_build_setup
 
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 ( startgroup "Validating outputs" ) 2> /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 
 language: generic
-dist: focal
+
 
 
 matrix:
@@ -10,18 +10,22 @@ matrix:
     - env: CONFIG=linux_ppc64le_python3.6.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
+      dist: focal
 
     - env: CONFIG=linux_ppc64le_python3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
+      dist: focal
 
     - env: CONFIG=linux_ppc64le_python3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
+      dist: focal
 
     - env: CONFIG=linux_ppc64le_python3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
+      dist: focal
 
 script:
   - export CI=travis

--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=431&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hyperspy-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=431&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hyperspy-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=431&branchName=master">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,8 @@
+build_platform:
+  osx_arm64: osx_64
 provider:
   win: azure
   linux_ppc64le: default
   linux_aarch64: default
 conda_forge_output_validation: true
+test_on_native_only: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -131,8 +131,7 @@ outputs:
         - hyperspy-gui-ipywidgets >=1.3
         - hyperspy-gui-traitsui >=1.3
         - imagecodecs
-        - matplotlib  # [not arm64]
-        - matplotlib-base  # [arm64]
+        - matplotlib
         - mrcz
         - python
         - pyusid >=0.0.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 303def6f59057f0fc228fa2947754aff362ec444671a3bf2264d0020f4f448d8
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   host:
@@ -22,6 +22,9 @@ outputs:
     script: install.bat  # [win]
     requirements:
       build:
+        - python                              # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+        - cython                              # [build_platform != target_platform]
         - {{ compiler('c') }}
       host:
         - cython
@@ -128,9 +131,9 @@ outputs:
         - hyperspy-gui-ipywidgets >=1.3
         - hyperspy-gui-traitsui >=1.3
         - imagecodecs
-        - matplotlib
+        - matplotlib  # [not arm64]
+        - matplotlib-base  # [arm64]
         - mrcz
-        - pyqt
         - python
         - pyusid >=0.0.7
         - sidpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,10 +117,10 @@ outputs:
         - set MPLBACKEND=agg  # [win]
         # Tidy up for next hyperspy release
         # Skip the "load_readonly" test, not working with latest dask (bug in the test itself)
-        - pytest --pyargs hyperspy -n 2 -k "not load_readonly"  # [not (aarch64 or ppc64le or win)]
+        - pytest --pyargs hyperspy -n 2 -k "not load_readonly and not test_plot_spectra"  # [not (aarch64 or ppc64le or win)]
         - pytest --pyargs hyperspy -k "not load_readonly"  # [win]
         # Skip the "crop_left" test (bug in the test itself)
-        - pytest --pyargs hyperspy -n 4 -k "not load_readonly and not crop_left"  # [aarch64]
+        - pytest --pyargs hyperspy -n 4 -k "not load_readonly and not crop_left and not test_plot_spectra"  # [aarch64]
 
   - name: hyperspy
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,10 +117,9 @@ outputs:
         - set MPLBACKEND=agg  # [win]
         # Tidy up for next hyperspy release
         # Skip the "load_readonly" test, not working with latest dask (bug in the test itself)
-        - pytest --pyargs hyperspy -n 2 -k "not load_readonly and not test_plot_spectra"  # [not (aarch64 or ppc64le or win)]
-        - pytest --pyargs hyperspy -k "not load_readonly"  # [win]
+        - pytest --pyargs hyperspy --dist loadfile -n 2 -k "not load_readonly"  # [not (aarch64 or ppc64le)]
         # Skip the "crop_left" test (bug in the test itself)
-        - pytest --pyargs hyperspy -n 4 -k "not load_readonly and not crop_left and not test_plot_spectra"  # [aarch64]
+        - pytest --pyargs hyperspy --dist loadfile -n 4 -k "not load_readonly and not crop_left"  # [aarch64]
 
   - name: hyperspy
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,10 +114,10 @@ outputs:
         - pip check
         - export MPLBACKEND=agg  # [unix]
         - set MPLBACKEND=agg  # [win]
-        - pytest --pyargs hyperspy  # [not (aarch64 or ppc64le)]
-        # Skip this "crop_left" test (bug in the test itself)
-        # Skip this "RPCA" test, which seems to be hanging the build on travis
-        - pytest --pyargs hyperspy -k "not RPCA and not crop_left"  # [aarch64]
+        - pytest --pyargs hyperspy -k "not load_readonly" # [not (aarch64 or ppc64le)]
+        # Skip the "load_readonly" test, not working with latest dask (bug in the test itself)
+        # Skip the "crop_left" test (bug in the test itself)
+        - pytest --pyargs hyperspy -k "not load_readonly and not crop_left"  # [aarch64]
 
   - name: hyperspy
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,7 +114,7 @@ outputs:
         - pip check
         - export MPLBACKEND=agg  # [unix]
         - set MPLBACKEND=agg  # [win]
-        - pytest --pyargs hyperspy -k "not load_readonly" # [not (aarch64 or ppc64le)]
+        - pytest --pyargs hyperspy -k "not load_readonly"  # [not (aarch64 or ppc64le)]
         # Skip the "load_readonly" test, not working with latest dask (bug in the test itself)
         # Skip the "crop_left" test (bug in the test itself)
         - pytest --pyargs hyperspy -k "not load_readonly and not crop_left"  # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,7 @@ outputs:
       requires:
         - pip
         - pytest
+        - pytest-xdist
       imports:
         - hyperspy
         - hyperspy.Release
@@ -114,10 +115,12 @@ outputs:
         - pip check
         - export MPLBACKEND=agg  # [unix]
         - set MPLBACKEND=agg  # [win]
-        - pytest --pyargs hyperspy -k "not load_readonly"  # [not (aarch64 or ppc64le)]
+        # Tidy up for next hyperspy release
         # Skip the "load_readonly" test, not working with latest dask (bug in the test itself)
+        - pytest --pyargs hyperspy -n 2 -k "not load_readonly"  # [not (aarch64 or ppc64le or win)]
+        - pytest --pyargs hyperspy -k "not load_readonly"  # [win]
         # Skip the "crop_left" test (bug in the test itself)
-        - pytest --pyargs hyperspy -k "not load_readonly and not crop_left"  # [aarch64]
+        - pytest --pyargs hyperspy -n 4 -k "not load_readonly and not crop_left"  # [aarch64]
 
   - name: hyperspy
     build:


### PR DESCRIPTION
See https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/#how-to-add-a-osx-arm64-build-to-a-feedstock

- Add osx-arm64 build
- remove `pyqt` dependency in `hyperspy` output, as it is taken care by user or other libraries (matplotlib)
- use `pytest-xdist` and `--dist loadfile` to speed up running test suite
- skip test failing with latest dask.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
