### PR TITLE
Fix macos python310 test hanging

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,11 +117,7 @@ outputs:
         - pip check
         - export MPLBACKEND=agg  # [unix]
         - set MPLBACKEND=agg  # [win]
-        # Tidy up for next hyperspy release
-        # Skip the "load_readonly" test, not working with latest dask (bug in the test itself)
-        - pytest --pyargs hyperspy --dist loadfile -n 2 -k "not load_readonly"  # [not (aarch64 or ppc64le)]
-        # Skip the "crop_left" test (bug in the test itself)
-        - pytest --pyargs hyperspy --dist loadfile -n 4 -k "not load_readonly and not crop_left"  # [aarch64]
+        - pytest --pyargs hyperspy --dist loadfile -n 2  # [not ppc64le]
 
   - name: hyperspy
     build:
@@ -151,8 +147,8 @@ outputs:
         - python
       run:
         - cython
-        - freetype >=2.9,<2.10  # [not py==39]
-        - matplotlib-base >=3.1,<3.2  # [not py==39]
+        - freetype >=2.9,<2.10  # [py<=38]
+        - matplotlib-base >=3.1,<3.2  # [py<=38]
         - numpydoc
         - pytest
         - pytest-mpl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 040d21c40e609d6c4b7b2c9e283a5ccf398450f5996a1dc2442d29e44e03793a
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   host:


### PR DESCRIPTION
which seems to fix a hanging test on macos python 3.10.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [n/a] Reset the build number to `0` (if the version changed)
* [n/a] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [n/a] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
