### PR TITLE
Fix osx-arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 49b3ea491fb5392227e7bcdbd8028c47b8c5aa9346dac58e02bff08f06ea1244
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -132,7 +132,7 @@ outputs:
       run:
         - {{ pin_subpackage('hyperspy-base', exact=True) }}
         - hyperspy-gui-ipywidgets >=1.3
-        - hyperspy-gui-traitsui >=1.3
+        - hyperspy-gui-traitsui >=1.3  # [not arm64]
         - imagecodecs
         - matplotlib
         - mrcz


### PR DESCRIPTION
Since `pyqt` is not available yet on osx-arm64, it is convenient not to include `hyperspy-gui-traitsui` in the `hyperspy` metapackage, otherwise `hyperspy` can't be installed on that platform.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [n/a] Reset the build number to `0` (if the version changed)
* [n/a] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [n/a] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
